### PR TITLE
jpype1 1.5.2 (rebuild)

### DIFF
--- a/recipe/0001-change-javac-target.patch
+++ b/recipe/0001-change-javac-target.patch
@@ -7,7 +7,7 @@ index a40ba066..e7f68f64 100644
              "Jar cache is missing, using --enable-build-jar to recreate it.")
  
 -        target_version = "1.8"
-+        target_version = "21"
++        target_version = "11"
          # build the jar
          try:
              dirname = os.path.dirname(self.get_ext_fullpath("JAVA"))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0002-fix-find_libjvm-windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   # Missing openjdk for s390x (not supported)
   skip: True  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - python
-        - openjdk >=21
+        - openjdk ==21.0.6
       host:
         - python
         - pip
@@ -45,7 +45,7 @@ outputs:
       run:
         - python
         - packaging
-        - openjdk >=21
+        - openjdk ==21.0.6
     test:
       files:
         - simple_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,9 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - python
-        - openjdk {{ min_openjdk_version }}
+        - openjdk {{ min_openjdk_version }}  # [not aarch64]
+        # openjdk 11 is not available for linux-aarch64, but we can build with 21 (and support only 21)
+        - openjdk >={{ min_openjdk_version }}  # [aarch64]
       host:
         - python
         - pip
@@ -78,6 +80,8 @@ outputs:
     build:
       # ant not available for osx-arm64
       skip: True  # [arm64]
+      # openjdk 11 not available for linux-aarch64
+      skip: True  # [aarch64]
     script: build_test.sh   # [unix]
     script: build_test.bat  # [win]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set version = "1.5.2" %}
 {% set name = "jpype1" %}
+{% set min_openjdk_version = "11.0.13" %}
 
 package:
   name: {{ name|lower }}-split
@@ -36,7 +37,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - python
-        - openjdk ==21.0.6
+        - openjdk {{ min_openjdk_version }}
       host:
         - python
         - pip
@@ -45,7 +46,7 @@ outputs:
       run:
         - python
         - packaging
-        - openjdk ==21.0.6
+        - openjdk >={{ min_openjdk_version }}
     test:
       files:
         - simple_test.py
@@ -73,7 +74,7 @@ outputs:
     {% set tests_to_skip = tests_to_skip + " or testOldStyleNonASCIIPath" %}  # [win]
     {% set tests_to_skip = tests_to_skip + " or testServiceWithNonASCIIPath" %}  # [win]
 
-  - name: jpype1-test
+  - name: jpype1-test-openjdk-11
     build:
       # ant not available for osx-arm64
       skip: True  # [arm64]
@@ -82,11 +83,46 @@ outputs:
     requirements:
       build:
         - ant
+        - openjdk ==11.*
       host:
         - python
         - setuptools
         - wheel
       run:
+        - openjdk ==11.*
+        - python
+        - {{ pin_subpackage('jpype1', exact=True) }}
+    test:
+      source_files:
+       - test
+      imports:
+       - jpype
+      commands:
+        - pip check
+        - pytest -vv test/jpypetest --checkjni {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"
+      requires:
+        - python
+        - pip
+        - pytest
+        - pyinstaller
+        - jedi >=0.18.0
+
+  - name: jpype1-test-openjdk-21
+    build:
+      # ant not available for osx-arm64
+      skip: True  # [arm64]
+    script: build_test.sh   # [unix]
+    script: build_test.bat  # [win]
+    requirements:
+      build:
+        - ant
+        - openjdk ==21.*
+      host:
+        - python
+        - setuptools
+        - wheel
+      run:
+        - openjdk ==21.*
         - python
         - {{ pin_subpackage('jpype1', exact=True) }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ outputs:
       run:
         - python
         - packaging
-      run_constrained:
         - openjdk >=21
     test:
       files:
@@ -61,7 +60,6 @@ outputs:
       requires:
         - pip
         - python
-        - openjdk >=21
 
     # We don't have java sql drivers required to run test_sql* tests
     {% set tests_to_ignore = " --ignore-glob=\"test/jpypetest/test_sql*\"" %}
@@ -105,7 +103,6 @@ outputs:
         - pytest
         - pyinstaller
         - jedi >=0.18.0
-        - openjdk
 
 about:
   home: https://github.com/jpype-project/jpype


### PR DESCRIPTION
jpype1 1.5.2 

**Destination channel:** Defaults

### Links

- [PKG-7342]
- dev_url:        https://github.com/jpype-project/jpype/tree/v1.5.2
- conda_forge:    https://github.com/conda-forge/jpype1-feedstock
- pypi:           https://pypi.org/project/jpype1/1.5.2
- pypi inspector: https://inspector.pypi.io/project/jpype1/1.5.2

### Explanation of changes:

- require openjdk in runtime (not in `run_constrained`)
- build with openjdk 11 to support both 11 and 21


[PKG-7342]: https://anaconda.atlassian.net/browse/PKG-7342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ